### PR TITLE
[Do not Merge]fix: renovate failure due to provider changes

### DIFF
--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -7,7 +7,7 @@ terraform {
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "1.20.0"
+      version = "2.0.1"
     }
   }
 }

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -7,7 +7,7 @@ terraform {
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "1.20.0"
+      version = "2.0.1"
     }
   }
 }

--- a/modules/configure_project/main.tf
+++ b/modules/configure_project/main.tf
@@ -1,13 +1,14 @@
 resource "restapi_object" "configure_project" {
-  path           = local.dataplatform_api
-  read_path      = "${local.dataplatform_api}{id}"
-  read_method    = "GET"
-  create_path    = "${local.dataplatform_api}/transactional/v2/projects?verify_unique_name=true"
-  create_method  = "POST"
-  id_attribute   = "location"
-  destroy_method = "DELETE"
-  destroy_path   = "${local.dataplatform_api}/transactional{id}"
-  data           = <<-EOT
+  ignore_all_server_changes = true # Refer (PR-216)[https://github.com/Mastercard/terraform-provider-restapi/pull/216]
+  path                      = local.dataplatform_api
+  read_path                 = "${local.dataplatform_api}{id}"
+  read_method               = "GET"
+  create_path               = "${local.dataplatform_api}/transactional/v2/projects?verify_unique_name=true"
+  create_method             = "POST"
+  id_attribute              = "location"
+  destroy_method            = "DELETE"
+  destroy_path              = "${local.dataplatform_api}/transactional{id}"
+  data                      = <<-EOT
                   {
                     "name": "${var.project_name}",
                     "generator": "terraform-ibm-watsonx-ai",
@@ -36,9 +37,9 @@ resource "restapi_object" "configure_project" {
                     }
                   }
                   EOT
-  update_method  = "PATCH"
-  update_path    = "${local.dataplatform_api}{id}"
-  update_data    = <<-EOT
+  update_method             = "PATCH"
+  update_path               = "${local.dataplatform_api}{id}"
+  update_data               = <<-EOT
                   {
                     "name": "${var.project_name}",
                     "type": "wx",

--- a/solutions/fully-configurable/version.tf
+++ b/solutions/fully-configurable/version.tf
@@ -8,7 +8,7 @@ terraform {
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "1.20.0"
+      version = "2.0.1"
     }
   }
 }


### PR DESCRIPTION
### Description

This PR provides fix to address renovate [PR](https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-ai/pull/85) failure which is failing from past few weeks and contains the following updates:

| Package | Type | Update | Change |
|---|---|---|---|
| [restapi](https://registry.terraform.io/providers/mastercard/restapi) ([source](https://redirect.github.com/Mastercard/terraform-provider-restapi)) | required_provider | major | `1.20.0` -> `2.0.1` |

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [x] Major release (`X.x.x`)

--- 

#### Release notes content

<details>
<summary>Mastercard/terraform-provider-restapi (restapi)</summary>

### [`v2.0.1`](https://redirect.github.com/Mastercard/terraform-provider-restapi/releases/tag/v2.0.1)

[Compare Source](https://redirect.github.com/Mastercard/terraform-provider-restapi/compare/v2.0.0...v2.0.1)

#### Fixed

-   Fix a case where the provider crashes during delta comparison if `null` is a value in the `data` field. Thanks for the report in [#&#8203;287](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/287), [@&#8203;lonelyelk](https://redirect.github.com/lonelyelk)!

### [`v2.0.0`](https://redirect.github.com/Mastercard/terraform-provider-restapi/releases/tag/v2.0.0)

[Compare Source](https://redirect.github.com/Mastercard/terraform-provider-restapi/compare/v1.20.0...v2.0.0)

#### New

-   [@&#8203;michaelPotter](https://redirect.github.com/michaelPotter) added an **awesome** new feature to detect/repair remote changes in [#&#8203;216](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/216) aligned with Terraform's test/repair paradigm! See `ignore_changes_to` and `ignore_all_server_changes`!
-   You can set which CAs you trust in the provider directly instead of using only the system-managed certs thanks to [#&#8203;270](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/270) by [@&#8203;daniel-butler-irl](https://redirect.github.com/daniel-butler-irl)!
-   Thanks to [@&#8203;Wiston999](https://redirect.github.com/Wiston999) in [#&#8203;266](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/266), you can pass `search_data` as a body to performing searches!

#### Fixed

-   Fix a case where missing resources don't get recreated by Terraform. Thanks, [@&#8203;mauriceackel](https://redirect.github.com/mauriceackel) for [#&#8203;282](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/282)!
-   You can search for boolean values now. Thanks for the bug report in [#&#8203;227](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/227), Mykhailo-Roit!

#### Misc

-   Thanks for the shell of SECURITY.md in [#&#8203;261](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/261), [@&#8203;ScorpiusDraconis83](https://redirect.github.com/ScorpiusDraconis83)
-   Updated LICENSE file to match full APLv2 text so GitHub API reports the correct license. Thanks for the heads up in [#&#8203;238](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/238), [@&#8203;EhrichPeter](https://redirect.github.com/EhrichPeter)!
-   Avoid logging potentially sensitive data unless debug mode is enabled. Thanks for the report in [#&#8203;276](https://redirect.github.com/Mastercard/terraform-provider-restapi/issues/276), [@&#8203;karand1979](https://redirect.github.com/karand1979)

</details>

---

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
